### PR TITLE
Fix log colors define

### DIFF
--- a/src/abcc_log.c
+++ b/src/abcc_log.c
@@ -24,7 +24,7 @@
 ** ANSI color codes for prettier prints
 **------------------------------------------------------------------------------
 */
-#ifdef ABCC_CFG_LOG_COLORS_ENABLED
+#if ABCC_CFG_LOG_COLORS_ENABLED
    #define ABCC_LOG_ANSI_COLOR_BLACK   "\x1b[30m"
    #define ABCC_LOG_ANSI_COLOR_RED     "\x1b[31m"
    #define ABCC_LOG_ANSI_COLOR_GREEN   "\x1b[32m"


### PR DESCRIPTION
It was not possible to disable colored logs as #ifdef was used instead of #if