### PR TITLE
Add posibility to specify CMake lib type via ABCC_LIB_TYPE

### DIFF
--- a/abcc-driver.cmake
+++ b/abcc-driver.cmake
@@ -56,9 +56,15 @@ set(abcc_driver_INCS
    ${ABCC_DRIVER_DIR}/src/serial/abcc_driver_serial_interface.h
 )
 
+# Check if ABCC_LIB_TYPE is not already defined. ABCC_LIB_TYPE can be set in a
+# higher level CMake file to the desired library type of the Anybus CompactCom Driver.
+if(NOT DEFINED ABCC_LIB_TYPE)
+    set(ABCC_LIB_TYPE STATIC)
+endif()
+
 # Creating a library target containing the Anybus CompactCom Driver.
 # The header files are added only to keep the file and directory tree structure.
-add_library(abcc_driver STATIC 
+add_library(abcc_driver ${ABCC_LIB_TYPE}
    ${abcc_driver_SRCS}
    ${abcc_driver_INCS}
 )


### PR DESCRIPTION
The variable ABCC_LIB_TYPE can be created in the user CMake file and set to the desired library type of the Anybus CompactCom Driver. If ABCC_LIB_TYPE is not defined in the user CMake file, it will take the default value of STATIC.