### PR TITLE
Added missing 'set message field' macros

### DIFF
--- a/inc/abcc_message.h
+++ b/inc/abcc_message.h
@@ -190,10 +190,15 @@ while( 0 )
 ** ABCC_SetMsgDataSize( psMsg, iDataSizeVal ) - Set message data size
 **                                              (in octets)
 ** ABCC_GetMsgInstance( psMsg )               - Message instance
+** ABCC_SetMsgInstance( psMsg, iInstanceVal ) - Set message instance
 ** ABCC_GetMsgSourceId( psMsg )               - Message source id
+** ABCC_SetMsgSourceId( psMsg, bSrcIdVal )    - Set message source id
 ** ABCC_GetMsgDestObj( psMsg )                - Destination object
+** ABCC_SetMsgDestObj( psMsg, bDestObjVal )   - Set destination object
 ** ABCC_IsCmdMsg( psMsg )                     - Message command bit
 ** ABCC_GetMsgCmdBits( psMsg )                - Message command
+** ABCC_GetMsgCmdField( psMsg )               - Entire command field
+** ABCC_SetMsgCmdField( psMsg, bCmdVal )      - Set entire command field
 ** ABCC_GetMsgCmdExt0( psMsg )                - Command extension 0
 ** ABCC_SetMsgCmdExt0( psMsg, bCmdExt0Val )   - Set command extension 0
 ** ABCC_GetMsgCmdExt1( psMsg )                - Command extension 1
@@ -213,9 +218,13 @@ while( 0 )
 #define ABCC_GetMsgInstance( psMsg               ) ( iLeTOi(               ((ABP_MsgHeaderType16*) (psMsg))->iInstance                                ) )
 #define ABCC_SetMsgInstance( psMsg, iInstanceVal ) (                       ((ABP_MsgHeaderType16*) (psMsg))->iInstance ) = iTOiLe( iInstanceVal )
 #define ABCC_GetMsgSourceId( psMsg               ) ( ABCC_GetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iSourceIdDestObj                         ) )
+#define ABCC_SetMsgSourceId( psMsg, bSrcIdVal    )   ABCC_SetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iSourceIdDestObj, bSrcIdVal              )
 #define ABCC_GetMsgDestObj(  psMsg               ) ( ABCC_GetHighAddrOct(  ((ABP_MsgHeaderType16*) (psMsg))->iSourceIdDestObj                         ) )
+#define ABCC_SetMsgDestObj(  psMsg, bDestObjVal  )   ABCC_SetHighAddrOct(  ((ABP_MsgHeaderType16*) (psMsg))->iSourceIdDestObj, bDestObjVal            )
 #define ABCC_IsCmdMsg(       psMsg               ) ( ABCC_GetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iCmdReserved ) & ABP_MSG_HEADER_C_BIT    )
 #define ABCC_GetMsgCmdBits(  psMsg               ) ( ABCC_GetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iCmdReserved ) & ABP_MSG_HEADER_CMD_BITS )
+#define ABCC_GetMsgCmdField( psMsg               ) ( ABCC_GetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iCmdReserved                             ) )
+#define ABCC_SetMsgCmdField( psMsg, bCmdVal      )   ABCC_SetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iCmdReserved, bCmdVal                    )
 #define ABCC_GetMsgCmdExt0(  psMsg               ) ( ABCC_GetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iCmdExt0CmdExt1                          ) )
 #define ABCC_SetMsgCmdExt0(  psMsg, bCmdExt0Val  )   ABCC_SetLowAddrOct(   ((ABP_MsgHeaderType16*) (psMsg))->iCmdExt0CmdExt1, bCmdExt0Val             )
 #define ABCC_GetMsgCmdExt1(  psMsg               ) ( ABCC_GetHighAddrOct(  ((ABP_MsgHeaderType16*) (psMsg))->iCmdExt0CmdExt1                          ) )
@@ -230,9 +239,13 @@ while( 0 )
 #define ABCC_GetMsgInstance( psMsg               ) ( iLeTOi( ((ABP_MsgHeaderType*)   (psMsg))->iInstance                          ) )
 #define ABCC_SetMsgInstance( psMsg, iInstanceVal ) (         ((ABP_MsgHeaderType*)   (psMsg))->iInstance ) = iTOiLe( iInstanceVal )
 #define ABCC_GetMsgSourceId( psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bSourceId                          )
+#define ABCC_SetMsgSourceId( psMsg, bSrcIdVal    ) (         ((ABP_MsgHeaderType*)   (psMsg))->bSourceId   = (bSrcIdVal)          )
 #define ABCC_GetMsgDestObj(  psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bDestObj                           )
+#define ABCC_SetMsgDestObj(  psMsg, bDestObjVal  ) (         ((ABP_MsgHeaderType*)   (psMsg))->bDestObj    = (bDestObjVal)        )
 #define ABCC_IsCmdMsg(       psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmd & ABP_MSG_HEADER_C_BIT        )
 #define ABCC_GetMsgCmdBits(  psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmd & ABP_MSG_HEADER_CMD_BITS     )
+#define ABCC_GetMsgCmdField( psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmd                               )
+#define ABCC_SetMsgCmdField( psMsg, bCmdVal      ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmd        = (bCmdVal)            )
 #define ABCC_GetMsgCmdExt0(  psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmdExt0                           )
 #define ABCC_SetMsgCmdExt0(  psMsg, bCmdExt0Val  ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmdExt0        = (bCmdExt0Val)    )
 #define ABCC_GetMsgCmdExt1(  psMsg               ) (         ((ABP_MsgHeaderType*)   (psMsg))->bCmdExt1                           )

--- a/src/abcc_log.c
+++ b/src/abcc_log.c
@@ -64,12 +64,6 @@
 #define ABCC_LOG_INDENTATION ( ABCC_LOG_SEVERITY_LENGTH )
 #endif
 
-#ifdef ABCC_SYS_16_BIT_CHAR
-#define ABCC_GetMsgCmdField( psMsg )   ( ABCC_GetLowAddrOct( (psMsg)->sHeader.iCmdReserved ) )
-#else
-#define ABCC_GetMsgCmdField( psMsg )   ( (psMsg)->sHeader.bCmd )
-#endif
-
 void ABCC_LogHandler(
    ABCC_LogSeverityType eSeverity,
    ABCC_ErrorCodeType eErrorCode,


### PR DESCRIPTION
There were no macros to set the Source ID, DestObj, etc.