### PR TITLE
A7077A-55 SPI: add possibility to change message fragment size at runtime

### DIFF
--- a/inc/abcc.h
+++ b/inc/abcc.h
@@ -497,6 +497,21 @@ EXTFUNC ABCC_ErrorCodeType ABCC_ReturnMsgBuffer( ABP_MsgType** ppsBuffer );
 */
 EXTFUNC void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg );
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** ABCC_DrvNewMsgFragSize()
+** Sets the new message frament size (used for SPI, only).
+**------------------------------------------------------------------------------
+** Arguments:
+**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**
+** Returns:
+**       ABCC_ErrorCodeType
+**------------------------------------------------------------------------------
+*/
+EXTFUNC ABCC_ErrorCodeType ABCC_NewMsgFragSize(const UINT16 iReqMsgFragSize);
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 /*------------------------------------------------------------------------------
 ** Reads the module ID.
 **------------------------------------------------------------------------------

--- a/inc/abcc.h
+++ b/inc/abcc.h
@@ -499,8 +499,8 @@ EXTFUNC void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg );
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 /*------------------------------------------------------------------------------
-** ABCC_DrvNewMsgFragSize()
-** Sets the new message frament size (used for SPI, only).
+** ABCC_NewMsgFragSize()
+** Sets the new message fragment size (used for SPI, only).
 **------------------------------------------------------------------------------
 ** Arguments:
 **       iReqMsgFragSize:   requested Size of message fragment (bytes)

--- a/inc/abcc.h
+++ b/inc/abcc.h
@@ -509,7 +509,7 @@ EXTFUNC void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg );
 **       ABCC_ErrorCodeType
 **------------------------------------------------------------------------------
 */
-EXTFUNC ABCC_ErrorCodeType ABCC_NewMsgFragSize(const UINT16 iReqMsgFragSize);
+EXTFUNC ABCC_ErrorCodeType ABCC_NewMsgFragSize( const UINT16 iReqMsgFragSize );
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -213,7 +213,7 @@
 ** If messages are important the fragment length should be set to the largest
 ** message to avoid fragmentation. If IO data are important the message fragment
 ** length should be set to a smaller value to speed up the SPI transaction.
-** For high message performance a fragment length up to 1536 octets
+** For high message performance a fragment length of up to 1536 octets
 ** (ABP_MAX_MSG_DATA_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF) is supported. The
 ** message header is 12 octets, so 16 or 32 octets will be enough to support
 ** small messages without fragmentation.
@@ -409,16 +409,15 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 ** time it takes to send the frame and therefore increase the performance for
 ** cyclic process data, but may increase the need for message fragmentation and
 ** reduce the throughput of the message interface.
-** For applications where message speed is not critical and cyclic process data
-** performance is important but specific use cases (like firmware updates)
-** require support for large messages, this define can be used to enable dynamic
-** message fragment length.
+** Enable dynamic message fragment length for applications where cyclic process
+** data performance is prioritized over message speed, but large messages (e.g.,
+** firmware updates) must still be supported with high performance.
 ** When dynamic message fragment length is enabled, the application can change
 ** the used message fragment size at runtime.
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-#define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN 0
+    #define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN 0
 #endif
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
@@ -435,11 +434,11 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-#define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + 12 )
+    #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + 12 )
 #endif
 
 #if ABCC_CFG_SPI_MAX_MSG_FRAG_LEN > ( ABCC_CFG_MAX_MSG_SIZE + 12 )
-#error "ABCC_CFG_SPI_MAX_MSG_FRAG_LEN must not be bigger than ABCC_CFG_MAX_MSG_SIZE + 12 (configured maximum message size including header)."
+    #error "ABCC_CFG_SPI_MAX_MSG_FRAG_LEN must not be bigger than ABCC_CFG_MAX_MSG_SIZE + 12 (configured maximum message size including header)."
 #endif
 
 /*------------------------------------------------------------------------------
@@ -447,30 +446,31 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 **
 ** Default value below can be overridden in abcc_driver_config.h
 **
-** When dynamic message fragment length is enabled, this define sets the minimum
-** message fragment length that can be used at runtime.
-** It is not recommended to use message fragment lengths that are too small.
-** The message header contains 12 octets. Therefore, 16 octets support
-** transmission of small messages without fragmentation and this value is used
-** as default.
-** Values below 8 will generate an (override-able) error since even an error
-** response message will need more than two SPI cycles, with smaller fragment
-** sizes.
-** Values below 2 are not allowed since without message fragment within an SPI
-** frame, no message transmission is possible at runtime.
+** Sets the minimum message fragment length allowed at runtime when dynamic
+** fragmentation is enabled.
+**
+** Note: Extremely small fragment lengths are discouraged. The message header
+** occupies 12 octets; therefore, a default of 16 octets allows small messages
+** to transmit without fragmentation.
+**
+** Constraints:
+** - Values < 8 trigger an override-able error, as even error responses would
+**   require more than two SPI cycles.
+** - Values < 2 are invalid, as a fragment must contain at least some payload
+**   data to be transmitted within an SPI frame.
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
-#define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN 16
+    #define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN 16
 #endif
 
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 8
-#ifndef ABCC_CFG_SPI_OVERRIDE_MIN_MSG_FRAG_LEN_ERROR
-#error "Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8. Override is possible by defining ABCC_CFG_SPI_OVERRIDE_MIN_MSG_FRAG_LEN_ERROR."
-#endif
+    #ifndef ABCC_CFG_SPI_OVERRIDE_MIN_MSG_FRAG_LEN_ERROR
+        #error "Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8. Override is possible by defining ABCC_CFG_SPI_OVERRIDE_MIN_MSG_FRAG_LEN_ERROR."
+    #endif
 #endif
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 2
-#error "Without message fragment within an SPI frame, no message transmission is possible at runtime. This is not allowed. ABCC_CFG_SPI_MIN_MSG_FRAG_LEN has to be 2 at least."
+    #error "Without message fragment within an SPI frame, no message transmission is possible at runtime. This is not allowed. ABCC_CFG_SPI_MIN_MSG_FRAG_LEN has to be 2 at least."
 #endif
 
 /*------------------------------------------------------------------------------
@@ -484,22 +484,22 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN
-#define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
+    #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
 #endif
 
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN == ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-#error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message fragment size to reduce code size."
+    #error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message fragment size to reduce code size."
 #endif
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-#error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+    #error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
 #endif
 
 #if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
-#error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be greater than or equal to ABCC_CFG_SPI_MIN_MSG_FRAG_LEN."
+    #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be greater than or equal to ABCC_CFG_SPI_MIN_MSG_FRAG_LEN."
 #endif
 
 #if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-#error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+    #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
 #endif
 
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -224,102 +224,6 @@
 #endif
 
 /*------------------------------------------------------------------------------
-** #define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN                   0
-**
-** Default value below can be overridden in abcc_driver_config.h
-**
-** By default, the length of the message fragment within a SPI frame is fixed.
-** Increasing the message fragment length reduces the need for fragmetnation and
-** increases the throughput of the message interface.
-** However, it also increases the size of the SPI frame and thus the time it
-** takes to send the fraame and therefore limits the performance for cyclic
-** process data.
-** Smaller message fragment lengths will reduce the SPI frame size and thus the
-** time it takes to send the frame and therefore increase the performance for
-** cyclic process data, but may increase the need for message fragmentation and
-** reduce the throughput of the message interface.
-** For Applications where message speed is not critical and cyclic process data
-** performance is important and specific use cases (like firmware updates)
-** require support for large messages, this define can be used to enable dynamic
-** message fragment length.
-** When dynamic message fragment length is enabled, the application can change
-** the used message frament size at runtime.
-**------------------------------------------------------------------------------
-*/
-#ifndef ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-    #define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN 0
-#endif
-
-#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-/*------------------------------------------------------------------------------
-** #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
-**
-** Default value below can be overridden in abcc_driver_config.h
-**
-** When dynamic message fragment length is enabled, this define sets the maximum
-** message fragment length that can be used at runtime.
-** The maximum message performance can be reached, when it is possible to fit a
-** full message (ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF) in the
-** message fragment.
-**------------------------------------------------------------------------------
-*/
-#ifndef ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-   #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
-#endif
-
-/*------------------------------------------------------------------------------
-** #define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN        16
-**
-** Default value below can be overridden in abcc_driver_config.h
-**
-** When dynamic message fragment length is enabled, this define sets the minimum
-** message fragment length that can be used at runtime.
-** It is not recommended to use message fragment lengths that are too small.
-** The message header contains 12 octets. therefore 16 octets support
-** transmission of small messages without fragmentation. Therefore, this value
-** is used as default.
-**------------------------------------------------------------------------------
-*/
-#ifndef ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
-   #define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN 16
-#endif
-
-#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 8
-   #pragma message("Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8.")  
-#endif
-
-/*------------------------------------------------------------------------------
-** #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
-**
-** Default value below can be overridden in abcc_driver_config.h
-**
-** When dynamic message fragment length is enabled, this define sets the default
-** message fragment length that is used before application defines another
-** length.
-**------------------------------------------------------------------------------
-*/
-#ifndef ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN
-   #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
-#endif
-
-#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN == ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-   #error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message frament size to reduce code size."
-#endif
-#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-   #error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
-#endif
-
-#if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
-   #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be greater than or equal to ABCC_CFG_SPI_MIN_MSG_FRAG_LEN."
-#endif
-
-#if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-   #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
-#endif
-
-#endif //#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-
-/*------------------------------------------------------------------------------
 ** #define ABCC_SPI_CRC_REDUCED_TABLE_ENABLED  1 - Enable / 0 - Disable
 **
 ** Default value below can be overridden in abcc_driver_config.h
@@ -489,6 +393,106 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 #ifndef ABCC_CFG_MAX_MSG_SIZE
     #define ABCC_CFG_MAX_MSG_SIZE ( 1524 )
 #endif
+
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN                   0
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** By default, the length of the message fragment within a SPI frame is fixed.
+** Increasing the message fragment length reduces the need for fragmetnation and
+** increases the throughput of the message interface.
+** However, it also increases the size of the SPI frame and thus the time it
+** takes to send the fraame and therefore limits the performance for cyclic
+** process data.
+** Smaller message fragment lengths will reduce the SPI frame size and thus the
+** time it takes to send the frame and therefore increase the performance for
+** cyclic process data, but may increase the need for message fragmentation and
+** reduce the throughput of the message interface.
+** For Applications where message speed is not critical and cyclic process data
+** performance is important and specific use cases (like firmware updates)
+** require support for large messages, this define can be used to enable dynamic
+** message fragment length.
+** When dynamic message fragment length is enabled, the application can change
+** the used message frament size at runtime.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+#define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN 0
+#endif
+
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** When dynamic message fragment length is enabled, this define sets the maximum
+** message fragment length that can be used at runtime.
+** The maximum message performance can be reached, when it is possible to fit a
+** full message (ABCC_CFG_MAX_MSG_SIZE + 12 bytes for the message header) in the
+** message fragment.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+#define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + 12 )
+#endif
+
+#if ABCC_CFG_SPI_MAX_MSG_FRAG_LEN > ( ABCC_CFG_MAX_MSG_SIZE + 12 )
+#error "ABCC_CFG_SPI_MAX_MSG_FRAG_LEN must not be bigger than the largest supported message size."
+#endif
+
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN        16
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** When dynamic message fragment length is enabled, this define sets the minimum
+** message fragment length that can be used at runtime.
+** It is not recommended to use message fragment lengths that are too small.
+** The message header contains 12 octets. therefore 16 octets support
+** transmission of small messages without fragmentation. Therefore, this value
+** is used as default.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
+#define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN 16
+#endif
+
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 8
+#pragma message("Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8.")  
+#endif
+
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** When dynamic message fragment length is enabled, this define sets the default
+** message fragment length that is used before application defines another
+** length.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN
+#define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
+#endif
+
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN == ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+#error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message frament size to reduce code size."
+#endif
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+#error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+#endif
+
+#if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
+#error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be greater than or equal to ABCC_CFG_SPI_MIN_MSG_FRAG_LEN."
+#endif
+
+#if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+#error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+#endif
+
+#endif //#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------
 ** #define ABCC_CFG_MAX_PROCESS_DATA_SIZE              ( 512 )

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -247,7 +247,7 @@
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-    #define ABCC_CFG_SPI_MSG_FRAG_LEN 0
+    #define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN 0
 #endif
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
@@ -285,7 +285,7 @@
 #endif
 
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 8
-   #warning "Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8."
+   #pragma message("Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8.")  
 #endif
 
 /*------------------------------------------------------------------------------
@@ -302,15 +302,21 @@
    #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
 #endif
 
-#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-   #error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN == ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+   #error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message frament size to reduce code size."
 #endif
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+   #error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+#endif
+
 #if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
    #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be greater than or equal to ABCC_CFG_SPI_MIN_MSG_FRAG_LEN."
 #endif
+
 #if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
    #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
 #endif
+
 #endif //#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -478,7 +478,7 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 #endif
 
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN == ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
-#error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message frament size to reduce code size."
+#error "Disable ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN for applications with static message fragment size to reduce code size."
 #endif
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
 #error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -400,21 +400,21 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 ** Default value below can be overridden in abcc_driver_config.h
 **
 ** By default, the length of the message fragment within a SPI frame is fixed.
-** Increasing the message fragment length reduces the need for fragmetnation and
+** Increasing the message fragment length reduces the need for fragmentation and
 ** increases the throughput of the message interface.
 ** However, it also increases the size of the SPI frame and thus the time it
-** takes to send the fraame and therefore limits the performance for cyclic
+** takes to send the frame and therefore limits the performance for cyclic
 ** process data.
 ** Smaller message fragment lengths will reduce the SPI frame size and thus the
 ** time it takes to send the frame and therefore increase the performance for
 ** cyclic process data, but may increase the need for message fragmentation and
 ** reduce the throughput of the message interface.
-** For Applications where message speed is not critical and cyclic process data
-** performance is important and specific use cases (like firmware updates)
+** For applications where message speed is not critical and cyclic process data
+** performance is important but specific use cases (like firmware updates)
 ** require support for large messages, this define can be used to enable dynamic
 ** message fragment length.
 ** When dynamic message fragment length is enabled, the application can change
-** the used message frament size at runtime.
+** the used message fragment size at runtime.
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -439,7 +439,7 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 #endif
 
 #if ABCC_CFG_SPI_MAX_MSG_FRAG_LEN > ( ABCC_CFG_MAX_MSG_SIZE + 12 )
-#error "ABCC_CFG_SPI_MAX_MSG_FRAG_LEN must not be bigger than the largest supported message size."
+#error "ABCC_CFG_SPI_MAX_MSG_FRAG_LEN must not be bigger than ABCC_CFG_MAX_MSG_SIZE + 12 (configured maximum message size including header)."
 #endif
 
 /*------------------------------------------------------------------------------

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -423,7 +423,7 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 /*------------------------------------------------------------------------------
-** #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
+** #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + 12 )
 **
 ** Default value below can be overridden in abcc_driver_config.h
 **
@@ -450,9 +450,14 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 ** When dynamic message fragment length is enabled, this define sets the minimum
 ** message fragment length that can be used at runtime.
 ** It is not recommended to use message fragment lengths that are too small.
-** The message header contains 12 octets. therefore 16 octets support
-** transmission of small messages without fragmentation. Therefore, this value
-** is used as default.
+** The message header contains 12 octets. Therefore, 16 octets support
+** transmission of small messages without fragmentation and this value is used
+** as default.
+** Values below 8 will generate an (override-able) error since even an error
+** response message will need more than two SPI cycles, with smaller fragment
+** sizes.
+** Values below 2 are not allowed since without message fragment within an SPI
+** frame, no message transmission is possible at runtime.
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
@@ -460,7 +465,12 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 #endif
 
 #if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 8
-#pragma message("Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8.")  
+#ifndef ABCC_CFG_SPI_OVERRIDE_MIN_MSG_FRAG_LEN_ERROR
+#error "Warning: Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8. Override is possible by defining ABCC_CFG_SPI_OVERRIDE_MIN_MSG_FRAG_LEN_ERROR."
+#endif
+#endif
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 2
+#error "Without message fragment within an SPI frame, no message transmission is possible at runtime. This is not allowed. ABCC_CFG_SPI_MIN_MSG_FRAG_LEN has to be 2 at least."
 #endif
 
 /*------------------------------------------------------------------------------

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -502,7 +502,7 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
 #endif
 
-#endif //#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------
 ** #define ABCC_CFG_MAX_PROCESS_DATA_SIZE              ( 512 )

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -213,14 +213,105 @@
 ** If messages are important the fragment length should be set to the largest
 ** message to avoid fragmentation. If IO data are important the message fragment
 ** length should be set to a smaller value to speed up the SPI transaction.
-** For high message performance a fragment length up to 1524 octets is
-** supported. The message header is 12 octets, so 16 or 32 octets will be enough
-** to support small messages without fragmentation.
+** For high message performance a fragment length up to 1536 octets
+** (ABP_MAX_MSG_DATA_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF) is supported. The
+** message header is 12 octets, so 16 or 32 octets will be enough to support
+** small messages without fragmentation.
 **------------------------------------------------------------------------------
 */
 #ifndef ABCC_CFG_SPI_MSG_FRAG_LEN
     #define ABCC_CFG_SPI_MSG_FRAG_LEN ( 32 )
 #endif
+
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN                   0
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** By default, the length of the message fragment within a SPI frame is fixed.
+** Increasing the message fragment length reduces the need for fragmetnation and
+** increases the throughput of the message interface.
+** However, it also increases the size of the SPI frame and thus the time it
+** takes to send the fraame and therefore limits the performance for cyclic
+** process data.
+** Smaller message fragment lengths will reduce the SPI frame size and thus the
+** time it takes to send the frame and therefore increase the performance for
+** cyclic process data, but may increase the need for message fragmentation and
+** reduce the throughput of the message interface.
+** For Applications where message speed is not critical and cyclic process data
+** performance is important and specific use cases (like firmware updates)
+** require support for large messages, this define can be used to enable dynamic
+** message fragment length.
+** When dynamic message fragment length is enabled, the application can change
+** the used message frament size at runtime.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+    #define ABCC_CFG_SPI_MSG_FRAG_LEN 0
+#endif
+
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** When dynamic message fragment length is enabled, this define sets the maximum
+** message fragment length that can be used at runtime.
+** The maximum message performance can be reached, when it is possible to fit a
+** full message (ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF) in the
+** message fragment.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+   #define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
+#endif
+
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN        16
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** When dynamic message fragment length is enabled, this define sets the minimum
+** message fragment length that can be used at runtime.
+** It is not recommended to use message fragment lengths that are too small.
+** The message header contains 12 octets. therefore 16 octets support
+** transmission of small messages without fragmentation. Therefore, this value
+** is used as default.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
+   #define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN 16
+#endif
+
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN < 8
+   #warning "Even an error response message will need more than two SPI cycles, as ABCC_CFG_SPI_MIN_MSG_FRAG_LEN is less than 8."
+#endif
+
+/*------------------------------------------------------------------------------
+** #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
+**
+** Default value below can be overridden in abcc_driver_config.h
+**
+** When dynamic message fragment length is enabled, this define sets the default
+** message fragment length that is used before application defines another
+** length.
+**------------------------------------------------------------------------------
+*/
+#ifndef ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN
+   #define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN
+#endif
+
+#if ABCC_CFG_SPI_MIN_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+   #error "ABCC_CFG_SPI_MIN_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+#endif
+#if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN
+   #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be greater than or equal to ABCC_CFG_SPI_MIN_MSG_FRAG_LEN."
+#endif
+#if ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN
+   #error "ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN must be smaller than or equal to ABCC_CFG_SPI_MAX_MSG_FRAG_LEN."
+#endif
+#endif //#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------
 ** #define ABCC_SPI_CRC_REDUCED_TABLE_ENABLED  1 - Enable / 0 - Disable

--- a/src/abcc_driver_interface.h
+++ b/src/abcc_driver_interface.h
@@ -358,7 +358,7 @@ EXTFUNC void ( *pnABCC_DrvSetPdSize )( const UINT16 iReadPdSize,
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 /*------------------------------------------------------------------------------
-** Sets the new message frament size (used for SPI, only).
+** Sets the new message fragment size (used for SPI, only).
 **------------------------------------------------------------------------------
 ** Arguments:
 **       iReqMsgFragSize:   requested Size of message fragment (bytes)

--- a/src/abcc_driver_interface.h
+++ b/src/abcc_driver_interface.h
@@ -367,7 +367,7 @@ EXTFUNC void ( *pnABCC_DrvSetPdSize )( const UINT16 iReadPdSize,
 **       ABCC_ErrorCodeType
 **------------------------------------------------------------------------------
 */
-EXTFUNC ABCC_ErrorCodeType ( *pnABCC_DrvNewMsgFragSize )( const UINT16 iReqMsgFragSize );
+EXTFUNC ABCC_ErrorCodeType( *pnABCC_DrvNewMsgFragSize )( const UINT16 iReqMsgFragSize );
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------

--- a/src/abcc_driver_interface.h
+++ b/src/abcc_driver_interface.h
@@ -361,7 +361,7 @@ EXTFUNC void ( *pnABCC_DrvSetPdSize )( const UINT16 iReadPdSize,
 ** Sets the new message fragment size (used for SPI, only).
 **------------------------------------------------------------------------------
 ** Arguments:
-**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**       iReqMsgFragSize:   Requested size of message fragment (bytes)
 **
 ** Returns:
 **       ABCC_ErrorCodeType

--- a/src/abcc_driver_interface.h
+++ b/src/abcc_driver_interface.h
@@ -356,6 +356,20 @@ EXTFUNC void ( *pnABCC_DrvSetAppStatus )( ABP_AppStatusType eAppStatus );
 EXTFUNC void ( *pnABCC_DrvSetPdSize )( const UINT16 iReadPdSize,
                                        const UINT16 iWritePdSize );
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** Sets the new message frament size (used for SPI, only).
+**------------------------------------------------------------------------------
+** Arguments:
+**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**
+** Returns:
+**       ABCC_ErrorCodeType
+**------------------------------------------------------------------------------
+*/
+EXTFUNC ABCC_ErrorCodeType ( *pnABCC_DrvNewMsgFragSize )( const UINT16 iReqMsgFragSize );
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 /*------------------------------------------------------------------------------
 ** Sets Interrupt mask according to h_aci.h.
 **------------------------------------------------------------------------------

--- a/src/abcc_handler.c
+++ b/src/abcc_handler.c
@@ -880,7 +880,7 @@ void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize )
 ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize( const UINT16 iReqMsgFragSize )
 {
    ABCC_LOG_INFO( "New message fragment size %" PRIu16 "\n", iReqMsgFragSize );
-   pnABCC_DrvNewMsgFragSize( iReqMsgFragSize );
+   return( pnABCC_DrvNewMsgFragSize( iReqMsgFragSize ) );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 

--- a/src/abcc_handler.c
+++ b/src/abcc_handler.c
@@ -866,7 +866,7 @@ void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg )
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 ABCC_ErrorCodeType ABCC_NewMsgFragSize( const UINT16 iReqMsgFragSize )
 {
-   return( ABCC_DrvNewMsgFragSize( iReqMsgFragSize ) );
+   return( pnABCC_DrvNewMsgFragSize( iReqMsgFragSize ) );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 

--- a/src/abcc_handler.c
+++ b/src/abcc_handler.c
@@ -167,6 +167,9 @@ static void TriggerWrPdUpdateNow( void )
       ** The data format of the process data is network specific.
       ** The application converts the data accordingly.
       */
+   #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+      abcc_pbWrPdBuffer = pnABCC_DrvGetWrPdBuffer();
+   #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
       if( ABCC_CbfUpdateWriteProcessData( abcc_pbWrPdBuffer ) )
       {
@@ -356,9 +359,9 @@ ABCC_ErrorCodeType ABCC_HwInit( void )
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 FOO )
+ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 iDroppedValue )
 {
-   (void) FOO;
+   (void) iDroppedValue;
    return( ABCC_EC_NO_ERROR );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
@@ -866,6 +869,7 @@ void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg )
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 ABCC_ErrorCodeType ABCC_NewMsgFragSize( const UINT16 iReqMsgFragSize )
 {
+   ABCC_LOG_INFO( "New message fragment size %" PRIu16 "\n", iReqMsgFragSize );
    return( pnABCC_DrvNewMsgFragSize( iReqMsgFragSize ) );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
@@ -875,14 +879,6 @@ void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize )
    ABCC_LOG_INFO( "New process data sizes RdPd %" PRIu16 " WrPd %" PRIu16 "\n", iReadPdSize, iWritePdSize );
    pnABCC_DrvSetPdSize( iReadPdSize, iWritePdSize );
 }
-
-#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize( const UINT16 iReqMsgFragSize )
-{
-   ABCC_LOG_INFO( "New message fragment size %" PRIu16 "\n", iReqMsgFragSize );
-   return( pnABCC_DrvNewMsgFragSize( iReqMsgFragSize ) );
-}
-#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 ABCC_ErrorCodeType ABCC_RunDriver( void )
 {

--- a/src/abcc_handler.c
+++ b/src/abcc_handler.c
@@ -359,7 +359,7 @@ ABCC_ErrorCodeType ABCC_HwInit( void )
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 iDroppedValue )
+static ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 iDroppedValue )
 {
    (void) iDroppedValue;
    return( ABCC_EC_NO_ERROR );

--- a/src/abcc_handler.c
+++ b/src/abcc_handler.c
@@ -88,6 +88,9 @@ BOOL ( *pnABCC_DrvISReadyForCmd )( void );
 void ( *pnABCC_DrvSetNbrOfCmds )( UINT8 bNbrOfCmds );
 void ( *pnABCC_DrvSetAppStatus )( ABP_AppStatusType eAppStatus );
 void ( *pnABCC_DrvSetPdSize )( const UINT16 iReadPdSize, const UINT16 iWritePdSize );
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+ABCC_ErrorCodeType(*pnABCC_DrvNewMsgFragSize)(const UINT16 iReqMsgFragSize);
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 void ( *pnABCC_DrvSetIntMask )( const UINT16 iIntMask );
 void* ( *pnABCC_DrvGetWrPdBuffer )( void );
 UINT16 ( *pnABCC_DrvGetModCap )( void );
@@ -352,6 +355,13 @@ ABCC_ErrorCodeType ABCC_HwInit( void )
    return( ABCC_EC_NO_ERROR );
 }
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 FOO)
+{
+   (void) FOO;
+   return(ABCC_EC_NO_ERROR);
+}
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 ABCC_ErrorCodeType ABCC_StartDriver( UINT32 lMaxStartupTimeMs )
 {
@@ -405,6 +415,9 @@ ABCC_ErrorCodeType ABCC_StartDriver( UINT32 lMaxStartupTimeMs )
       pnABCC_DrvSetNbrOfCmds       = &ABCC_DrvSerSetNbrOfCmds;
       pnABCC_DrvSetAppStatus       = &ABCC_DrvSerSetAppStatus;
       pnABCC_DrvSetPdSize          = &ABCC_DrvSerSetPdSize;
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+      pnABCC_DrvNewMsgFragSize     = &ABCC_DoNothing;
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
       pnABCC_DrvSetIntMask         = &ABCC_DrvSerSetIntMask;
       pnABCC_DrvGetWrPdBuffer      = &ABCC_DrvSerGetWrPdBuffer;
       pnABCC_DrvGetModCap          = &ABCC_DrvSerGetModCap;
@@ -441,6 +454,9 @@ ABCC_ErrorCodeType ABCC_StartDriver( UINT32 lMaxStartupTimeMs )
       pnABCC_DrvSetNbrOfCmds       = &ABCC_DrvSpiSetNbrOfCmds;
       pnABCC_DrvSetAppStatus       = &ABCC_DrvSpiSetAppStatus;
       pnABCC_DrvSetPdSize          = &ABCC_DrvSpiSetPdSize;
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+      pnABCC_DrvNewMsgFragSize     = &ABCC_DrvSpiNewMsgFragSize;
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
       pnABCC_DrvSetIntMask         = &ABCC_DrvSpiSetIntMask;
       pnABCC_DrvGetWrPdBuffer      = &ABCC_DrvSpiGetWrPdBuffer;
       pnABCC_DrvGetModCap          = &ABCC_DrvSpiGetModCap;
@@ -478,6 +494,9 @@ ABCC_ErrorCodeType ABCC_StartDriver( UINT32 lMaxStartupTimeMs )
       pnABCC_DrvSetNbrOfCmds       = &ABCC_DrvParSetNbrOfCmds;
       pnABCC_DrvSetAppStatus       = &ABCC_DrvParSetAppStatus;
       pnABCC_DrvSetPdSize          = &ABCC_DrvParSetPdSize;
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+      pnABCC_DrvNewMsgFragSize     = &ABCC_DoNothing;
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
       pnABCC_DrvSetIntMask         = &ABCC_DrvParSetIntMask;
       pnABCC_DrvGetWrPdBuffer      = &ABCC_DrvParGetWrPdBuffer;
       pnABCC_DrvGetModCap          = &ABCC_DrvParGetModCap;
@@ -844,11 +863,26 @@ void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg )
    ABCC_MemSetBufferStatus( psMsg, ABCC_MEM_BUFSTAT_OWNED );
 }
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+ABCC_ErrorCodeType ABCC_NewMsgFragSize(const UINT16 iReqMsgFragSize)
+{
+   return( ABCC_DrvNewMsgFragSize(iReqMsgFragSize) );
+}
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize )
 {
    ABCC_LOG_INFO( "New process data sizes RdPd %" PRIu16 " WrPd %" PRIu16 "\n", iReadPdSize, iWritePdSize );
    pnABCC_DrvSetPdSize( iReadPdSize, iWritePdSize );
 }
+
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize(const UINT16 iReqMsgFragSize)
+{
+   ABCC_LOG_INFO( "New message fragment size %" PRIu16 "\n", iReqMsgFragSize );
+   pnABCC_DrvNewMsgFragSize(iReqMsgFragSize);
+}
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 ABCC_ErrorCodeType ABCC_RunDriver( void )
 {

--- a/src/abcc_handler.c
+++ b/src/abcc_handler.c
@@ -89,7 +89,7 @@ void ( *pnABCC_DrvSetNbrOfCmds )( UINT8 bNbrOfCmds );
 void ( *pnABCC_DrvSetAppStatus )( ABP_AppStatusType eAppStatus );
 void ( *pnABCC_DrvSetPdSize )( const UINT16 iReadPdSize, const UINT16 iWritePdSize );
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType(*pnABCC_DrvNewMsgFragSize)(const UINT16 iReqMsgFragSize);
+ABCC_ErrorCodeType( *pnABCC_DrvNewMsgFragSize )( const UINT16 iReqMsgFragSize );
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 void ( *pnABCC_DrvSetIntMask )( const UINT16 iIntMask );
 void* ( *pnABCC_DrvGetWrPdBuffer )( void );
@@ -356,10 +356,10 @@ ABCC_ErrorCodeType ABCC_HwInit( void )
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 FOO)
+ABCC_ErrorCodeType ABCC_DoNothing( const UINT16 FOO )
 {
    (void) FOO;
-   return(ABCC_EC_NO_ERROR);
+   return( ABCC_EC_NO_ERROR );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
@@ -864,9 +864,9 @@ void ABCC_TakeMsgBufferOwnership( ABP_MsgType* psMsg )
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_NewMsgFragSize(const UINT16 iReqMsgFragSize)
+ABCC_ErrorCodeType ABCC_NewMsgFragSize( const UINT16 iReqMsgFragSize )
 {
-   return( ABCC_DrvNewMsgFragSize(iReqMsgFragSize) );
+   return( ABCC_DrvNewMsgFragSize( iReqMsgFragSize ) );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
@@ -877,10 +877,10 @@ void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize )
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize(const UINT16 iReqMsgFragSize)
+ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize( const UINT16 iReqMsgFragSize )
 {
    ABCC_LOG_INFO( "New message fragment size %" PRIu16 "\n", iReqMsgFragSize );
-   pnABCC_DrvNewMsgFragSize(iReqMsgFragSize);
+   pnABCC_DrvNewMsgFragSize( iReqMsgFragSize );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 

--- a/src/abcc_handler.h
+++ b/src/abcc_handler.h
@@ -89,7 +89,7 @@ EXTFUNC void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize
 **       ABCC_ErrorCodeType
 **------------------------------------------------------------------------------
 */
-EXTFUNC ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize(const UINT16 iReqMsgFragSize);
+EXTFUNC ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize( const UINT16 iReqMsgFragSize );
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 

--- a/src/abcc_handler.h
+++ b/src/abcc_handler.h
@@ -77,6 +77,22 @@ EXTVAR UINT16 ABCC_iInterruptEnableMask;
 EXTFUNC void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize );
 
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** ABCC_DrvNewMsgFragSize()
+** Sets the new message frament size (used for SPI, only).
+**------------------------------------------------------------------------------
+** Arguments:
+**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**
+** Returns:
+**       ABCC_ErrorCodeType
+**------------------------------------------------------------------------------
+*/
+EXTFUNC ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize(const UINT16 iReqMsgFragSize);
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
+
 /*------------------------------------------------------------------------------
 ** The anybus is ready for communication. This function shall be called either
 ** due to power up interrupt or initial handshake timeout

--- a/src/abcc_handler.h
+++ b/src/abcc_handler.h
@@ -77,22 +77,8 @@ EXTVAR UINT16 ABCC_iInterruptEnableMask;
 EXTFUNC void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize );
 
 
-#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-/*------------------------------------------------------------------------------
-** ABCC_DrvNewMsgFragSize()
-** Sets the new message frament size (used for SPI, only).
-**------------------------------------------------------------------------------
-** Arguments:
-**       iReqMsgFragSize:   requested Size of message fragment (bytes)
 **
 ** Returns:
-**       ABCC_ErrorCodeType
-**------------------------------------------------------------------------------
-*/
-EXTFUNC ABCC_ErrorCodeType ABCC_DrvNewMsgFragSize( const UINT16 iReqMsgFragSize );
-#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-
-
 /*------------------------------------------------------------------------------
 ** The anybus is ready for communication. This function shall be called either
 ** due to power up interrupt or initial handshake timeout

--- a/src/abcc_handler.h
+++ b/src/abcc_handler.h
@@ -76,9 +76,6 @@ EXTVAR UINT16 ABCC_iInterruptEnableMask;
 */
 EXTFUNC void ABCC_SetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize );
 
-
-**
-** Returns:
 /*------------------------------------------------------------------------------
 ** The anybus is ready for communication. This function shall be called either
 ** due to power up interrupt or initial handshake timeout

--- a/src/spi/abcc_driver_spi_interface.h
+++ b/src/spi/abcc_driver_spi_interface.h
@@ -181,7 +181,7 @@ EXTFUNC void ABCC_DrvSpiSetPdSize( const UINT16 iReadPdSize, const UINT16 iWrite
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 /*------------------------------------------------------------------------------
-** Sets the new message frament size for the SPI frame.
+** Sets the new message fragment size for the SPI frame.
 **------------------------------------------------------------------------------
 ** Arguments:
 **       iReqMsgFragSize:   requested Size of message fragment (bytes)

--- a/src/spi/abcc_driver_spi_interface.h
+++ b/src/spi/abcc_driver_spi_interface.h
@@ -179,6 +179,20 @@ EXTFUNC void ABCC_DrvSpiSetAppStatus( ABP_AppStatusType eAppStatus );
 */
 EXTFUNC void ABCC_DrvSpiSetPdSize( const UINT16 iReadPdSize, const UINT16 iWritePdSize );
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** Sets the new message frament size for the SPI frame.
+**------------------------------------------------------------------------------
+** Arguments:
+**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**
+** Returns:
+**       ABCC_ErrorCodeType
+**------------------------------------------------------------------------------
+*/
+EXTFUNC ABCC_ErrorCodeType ABCC_DrvSpiNewMsgFragSize( const UINT16 iReqMsgFragSize );
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 /*------------------------------------------------------------------------------
 ** Sets the receiver buffer, to be used for the next read message.
 **------------------------------------------------------------------------------

--- a/src/spi/abcc_driver_spi_interface.h
+++ b/src/spi/abcc_driver_spi_interface.h
@@ -184,7 +184,7 @@ EXTFUNC void ABCC_DrvSpiSetPdSize( const UINT16 iReadPdSize, const UINT16 iWrite
 ** Sets the new message fragment size for the SPI frame.
 **------------------------------------------------------------------------------
 ** Arguments:
-**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**       iReqMsgFragSize:   Requested size of message fragment (bytes)
 **
 ** Returns:
 **       ABCC_ErrorCodeType

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -242,47 +242,6 @@ void ABCC_DrvSpiRunDriverTx( void )
 
    if( spi_drv_eState ==  SM_SPI_RDY_TO_SEND_MOSI )
    {
-#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-      if( spi_drv_sSpiMsgFragSizeInfo.fUpdated )
-      {
-         if( spi_drv_iPdSize > 0 )
-         {
-            // shift process data to new offset in frame according to new
-            // message fragment size
-            if( spi_drv_iPdOffset < NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) )
-            {
-               // move process data towards the end of the frame
-               // => start copy at last word to avoid overwriting data in source
-               // location before it has been copied
-               i = spi_drv_iPdSize;
-               do
-               {
-                  i--;
-                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
-                     spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
-               }
-               while( i > 0 );
-            }
-            else
-            {
-               // move process data towards the beginning of the frame
-               // => start copy at first word to avoid overwriting data in
-               // source location before it has been copied
-               for( i = 0; i < spi_drv_iPdSize; i++ )
-               {
-                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
-                     spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
-               }
-            }
-         }
-         spi_drv_iPdOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
-         spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + spi_drv_iPdSize;
-         spi_drv_iMsgLen = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
-         spi_drv_sMosiFrame.iMsgLen = iTOiLe( spi_drv_iMsgLen );
-         spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
-      }
-#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-
       spi_drv_eState = SM_SPI_WAITING_FOR_MISO;
 
       if( !spi_drv_fRetransmit )
@@ -291,6 +250,57 @@ void ABCC_DrvSpiRunDriverTx( void )
          ** Everything is OK. Reset retransmission and toggle the T bit.
          */
          spi_drv_sMosiFrame.iSpiControl ^= iSpiCtrl_T;
+
+         #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+         if( spi_drv_sSpiMsgFragSizeInfo.fUpdated )
+         {
+            /*
+            ** The message fragment size has been updated since last 
+            ** transmission, update the frame layout accordingly.
+            */
+            if( spi_drv_iPdSize > 0 )
+            {
+               /*
+               ** shift process data to new offset in frame according to new
+               ** message fragment size
+               */
+               if( spi_drv_iPdOffset < NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) )
+               {
+                  /*
+                  ** move process data towards the end of the frame
+                  ** => start copy at last word to avoid overwriting data in 
+                  **    source location before it has been copied
+                  */
+                  i = spi_drv_iPdSize;
+                  do
+                  {
+                     i--;
+                     spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
+                        spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
+                  }
+                  while( i > 0 );
+               }
+               else
+               {
+                  /*
+                  ** move process data towards the beginning of the frame
+                  ** => start copy at first word to avoid overwriting data in
+                  **    source location before it has been copied
+                  */
+                  for( i = 0; i < spi_drv_iPdSize; i++ )
+                  {
+                     spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
+                        spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
+                  }
+               }
+            }
+            spi_drv_iPdOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
+            spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + spi_drv_iPdSize;
+            spi_drv_iMsgLen = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
+            spi_drv_sMosiFrame.iMsgLen = iTOiLe( spi_drv_iMsgLen );
+            spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
+         }
+         #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
       }
 
       spi_drv_fRetransmit = FALSE;

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -299,6 +299,8 @@ void ABCC_DrvSpiRunDriverTx( void )
             spi_drv_iMsgLen = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
             spi_drv_sMosiFrame.iMsgLen = iTOiLe( spi_drv_iMsgLen );
             spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
+
+            spi_drv_sSpiMsgFragSizeInfo.fUpdated = FALSE;
          }
          #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
       }

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -136,7 +136,7 @@ typedef struct
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 /*------------------------------------------------------------------------------
-** Info for dynamic SPI Message Fragment Size handling
+** Info for dynamic SPI message fragment size handling
 **------------------------------------------------------------------------------
 */
 typedef struct
@@ -203,10 +203,10 @@ static UINT16                       spi_drv_iMsgLen;              /* Message len
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 static drv_SpiMsgFragSizeInfoType   spi_drv_sSpiMsgFragSizeInfo =
-                                    {
-                                    FALSE,                        /* BOOL fUpdated */
-                                    ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN, /* UINT16 iMsgFragSizeReq */
-                                    };
+   {
+      FALSE,                                                      /* BOOL fUpdated */
+      ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN,                          /* UINT16 iMsgFragSizeReq */
+   };
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 static UINT16                       drv_iCrcErrorCount;           /* CRC error counter */
@@ -265,15 +265,17 @@ void ABCC_DrvSpiRunDriverTx( void )
             if( spi_drv_iPdSize > 0 )
             {
                /*
-               ** shift process data to new offset in frame according to new
+               ** Shift process data to new offset in frame according to new
                ** message fragment size
                */
                if( spi_drv_iPdOffset < NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer ) )
                {
                   /*
-                  ** move process data towards the end of the frame
-                  ** => start copy at last word to avoid overwriting data in 
-                  **    source location before it has been copied
+                  ** Move process data towards the end of the frame
+                  **
+                  ** Since source and destination can overlap within the same
+                  ** buffer, copy backwards from the last word to prevent
+                  ** overwriting source data before it is read.
                   */
                   i = spi_drv_iPdSize;
                   do
@@ -287,9 +289,12 @@ void ABCC_DrvSpiRunDriverTx( void )
                else
                {
                   /*
-                  ** move process data towards the beginning of the frame
-                  ** => start copy at first word to avoid overwriting data in
-                  **    source location before it has been copied
+                  ** Move process data towards the beginning of the frame
+                  **
+                  ** Since source and destination can overlap within the same
+                  ** buffer, copy forwards from the first word. This is safe
+                  ** because destination offset > source offset, so forward
+                  ** iteration will not overwrite unread source data.
                   */
                   for( i = 0; i < spi_drv_iPdSize; i++ )
                   {
@@ -312,9 +317,11 @@ void ABCC_DrvSpiRunDriverTx( void )
             else
             {
                /*
-               ** The message fragment size has been updated again since we
-               ** began to change it.
-               ** => repeat the update process on next driver call.
+               ** The requested message fragment size was modified while the
+               ** update process was in progress.
+               **
+               ** To ensure consistency, mark the update as pending and retry on
+               ** the next driver call.
                */
                spi_drv_sSpiMsgFragSizeInfo.fUpdated = TRUE;
             }
@@ -858,8 +865,12 @@ ABCC_ErrorCodeType ABCC_DrvSpiNewMsgFragSize( const UINT16 iReqMsgFragSize )
    }
    else if( NUM_BYTES_2_WORDS( iReqMsgFragSize ) == spi_drv_iPdOffset )
    {
-      // requested message fragment length is OK, but did not change
-      // => no need to update fragmentation info or frame offsets
+      /*
+      ** Requested message fragment size matches current configuration (no
+      ** change).
+      ** Store the value, but skip update of fragmentation info and frame
+      ** offsets.
+      */
       spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq = iReqMsgFragSize;
       spi_drv_sSpiMsgFragSizeInfo.fUpdated = FALSE;
    }

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -74,10 +74,14 @@ static const UINT16 iSpiStatusNewPd =     ABP_SPI_STATUS_NEW_PD << 8;
 #define CRC_WORD_LEN_IN_WORDS 2
 #define SPI_FRAME_SIZE_EXCLUDING_DATA (7)
 
-#if ABCC_CFG_SPI_MSG_FRAG_LEN > ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
-#error  "To prevent wasting SPI bandwidth, ABCC_CFG_SPI_MSG_FRAG_LEN cannot exceed (ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF)"
+#if !(ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN)
+   #if ABCC_CFG_SPI_MSG_FRAG_LEN > ( ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF )
+   #error  "To prevent wasting SPI bandwidth, ABCC_CFG_SPI_MSG_FRAG_LEN cannot exceed (ABCC_CFG_MAX_MSG_SIZE + ABCC_MSG_HEADER_TYPE_SIZEOF)"
+   #endif
+   #define MAX_PAYLOAD_WORD_LEN ( ( NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN ) ) + ( NUM_BYTES_2_WORDS( ABCC_CFG_MAX_PROCESS_DATA_SIZE ) ) + ( CRC_WORD_LEN_IN_WORDS ) )
+#else
+   #define MAX_PAYLOAD_WORD_LEN ( ( NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ) ) + ( NUM_BYTES_2_WORDS( ABCC_CFG_MAX_PROCESS_DATA_SIZE ) ) + ( CRC_WORD_LEN_IN_WORDS ) )   
 #endif
-#define MAX_PAYLOAD_WORD_LEN ( ( NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN ) ) + ( NUM_BYTES_2_WORDS( ABCC_CFG_MAX_PROCESS_DATA_SIZE ) ) + ( CRC_WORD_LEN_IN_WORDS ) )
 
 #define INSERT_SPI_CTRL_CMDCNT( ctrl, cmdcnt ) ctrl = ( ( ctrl ) & ~iSpiCtrlCmdCnt ) | ( ( cmdcnt ) << iSpiCtrlCmdCntShift )
 #define EXTRACT_SPI_STATUS_CMDCNT( status ) ( ( ( status ) & iSpiStatusCmdCnt ) >> iSpiStatusCmdCntShift )
@@ -129,6 +133,18 @@ typedef struct
   UINT16*            puCurrPtr;           /* Pointer to the current position in receive buffer. */
   UINT16             iNumWordsReceived;   /* Number of words received. */
 } drv_SpiReadMsgFragInfoType;
+
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** Info for dynamic SPI Message Fragment Size handling
+**------------------------------------------------------------------------------
+*/
+typedef struct
+{
+   BOOL     fUpdated;
+   UINT16   iMsgFragSizeReq;
+} drv_SpiMsgFragSizeInfoType;
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------
 ** Internal SPI states.
@@ -185,6 +201,14 @@ static BOOL                         fWdTmo;                       /* Current wd 
 
 static UINT16                       spi_drv_iMsgLen;              /* Message length ( in words ) */
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+static drv_SpiMsgFragSizeInfoType   spi_drv_sSpiMsgFragSizeInfo =
+                                    {
+                                    FALSE,                     //BOOL     fUpdated;
+                                    ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE,// UINT16   iMsgFragSizeReq;
+                                    };
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 static UINT16                       drv_iCrcErrorCount;           /* CRC error counter */
 
 static void spi_drv_DataReceived( void );
@@ -207,6 +231,9 @@ static void DrvSpiSetMsgReceiverBuffer( ABP_MsgType* const psReadMsg );
 */
 void ABCC_DrvSpiRunDriverTx( void )
 {
+   #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+   INT16 i;
+   #endif
    UINT32 lCrc;
    BOOL   fHandleWriteMsg = FALSE;
    UINT16 iRdyForCmd;
@@ -215,6 +242,46 @@ void ABCC_DrvSpiRunDriverTx( void )
 
    if( spi_drv_eState ==  SM_SPI_RDY_TO_SEND_MOSI )
    {
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+      if (spi_drv_sSpiMsgFragSizeInfo.fUpdated)
+      {
+         if ( spi_drv_iPdSize > 0 )
+         {
+            // shift process data to new offset in frame according to new
+            // message fragment size
+            if (spi_drv_iPdOffset < NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq))
+            {
+               // move process data towards the end of the frame
+               // => start copy at last word to avoid overwriting data in source
+               // location before it has been copied
+               i = spi_drv_iPdSize;
+               do(
+                  i--;
+                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq) + i ] =
+                     spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
+               )
+               while (i > 0);
+            }
+            else
+            {
+               // move process data towards the beginning of the frame
+               // => start copy at first word to avoid overwriting data in
+               // source location before it has been copied
+               for (i = 0; i < spi_drv_iPdSize; i++)
+               {
+                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq) + i ] =
+                     spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
+               }
+            }
+         }
+         spi_drv_iPdOffset = NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq);
+         spi_drv_iCrcOffset = NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq) + spi_drv_iPdSize;
+         spi_drv_iMsgLen = NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq);
+         spi_drv_sMosiFrame.iMsgLen = iTOiLe(spi_drv_iMsgLen);
+         spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
+      }
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
       spi_drv_eState = SM_SPI_WAITING_FOR_MISO;
 
       if( !spi_drv_fRetransmit )
@@ -595,13 +662,22 @@ void ABCC_DrvSpiInit( UINT8 bOpmode )
    spi_drv_iPdSize = SPI_DEFAULT_PD_LEN;
    spi_drv_iWritePdSize = SPI_DEFAULT_PD_LEN;
    spi_drv_iReadPdSize = SPI_DEFAULT_PD_LEN;
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+   spi_drv_iPdOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE );
+   spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE ) + SPI_DEFAULT_PD_LEN;
+#else
    spi_drv_iPdOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN );
    spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN ) + SPI_DEFAULT_PD_LEN;
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
    spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
    spi_drv_fRetransmit = FALSE;
    spi_drv_iMsgLen = 0;
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+   spi_drv_iMsgLen = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE );
+#else
    spi_drv_iMsgLen = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN );
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
    spi_drv_sMosiFrame.iMsgLen = iTOiLe( spi_drv_iMsgLen );
 
    spi_drv_sMosiFrame.iPdLen = iTOiLe( spi_drv_iPdSize );
@@ -736,6 +812,31 @@ void ABCC_DrvSpiSetPdSize( const UINT16  iReadPdSize, const UINT16  iWritePdSize
          (UINT32)spi_drv_eState, "Set PD size operation not allowed in this state (state: %d)\n", spi_drv_eState );
    }
 }
+
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+ABCC_ErrorCodeType ABCC_DrvSpiNewMsgFragSize(const UINT16 iReqMsgFragSize)
+{
+   ABCC_ErrorCodeType eReturn = ABCC_EC_NO_ERROR;
+   if (iReqMsgFragSize < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN )
+   {
+      eReturn = ABCC_EC_PARAMETER_NOT_VALID;
+   }
+   else if (iReqMsgFragSize > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN)
+   {
+      eReturn = ABCC_EC_PARAMETER_NOT_VALID;
+   }
+   else if (NUM_BYTES_2_WORDS(iReqMsgFragSize) == spi_drv_iPdOffset)
+   {
+      //message fragment length did not change
+      eReturn = ABCC_EC_PARAMETER_NOT_VALID;
+   }
+   {
+      spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq = iReqMsgFragSize;
+      spi_drv_sSpiMsgFragSizeInfo.fUpdated = TRUE;
+   }
+   return(eReturn);
+}
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 static void DrvSpiSetMsgReceiverBuffer( ABP_MsgType* const psReadMsg )
 {

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -243,41 +243,42 @@ void ABCC_DrvSpiRunDriverTx( void )
    if( spi_drv_eState ==  SM_SPI_RDY_TO_SEND_MOSI )
    {
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-      if (spi_drv_sSpiMsgFragSizeInfo.fUpdated)
+      if( spi_drv_sSpiMsgFragSizeInfo.fUpdated )
       {
-         if ( spi_drv_iPdSize > 0 )
+         if( spi_drv_iPdSize > 0 )
          {
             // shift process data to new offset in frame according to new
             // message fragment size
-            if (spi_drv_iPdOffset < NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq))
+            if( spi_drv_iPdOffset < NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) )
             {
                // move process data towards the end of the frame
                // => start copy at last word to avoid overwriting data in source
                // location before it has been copied
                i = spi_drv_iPdSize;
-               do(
+               do
+               {
                   i--;
-                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq) + i ] =
+                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
                      spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
-               )
-               while (i > 0);
+               }
+               while( i > 0 );
             }
             else
             {
                // move process data towards the beginning of the frame
                // => start copy at first word to avoid overwriting data in
                // source location before it has been copied
-               for (i = 0; i < spi_drv_iPdSize; i++)
+               for( i = 0; i < spi_drv_iPdSize; i++ )
                {
-                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq) + i ] =
+                  spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
                      spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
                }
             }
          }
-         spi_drv_iPdOffset = NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq);
-         spi_drv_iCrcOffset = NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq) + spi_drv_iPdSize;
-         spi_drv_iMsgLen = NUM_BYTES_2_WORDS(spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq);
-         spi_drv_sMosiFrame.iMsgLen = iTOiLe(spi_drv_iMsgLen);
+         spi_drv_iPdOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
+         spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + spi_drv_iPdSize;
+         spi_drv_iMsgLen = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
+         spi_drv_sMosiFrame.iMsgLen = iTOiLe( spi_drv_iMsgLen );
          spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
       }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
@@ -814,27 +815,30 @@ void ABCC_DrvSpiSetPdSize( const UINT16  iReadPdSize, const UINT16  iWritePdSize
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_DrvSpiNewMsgFragSize(const UINT16 iReqMsgFragSize)
+ABCC_ErrorCodeType ABCC_DrvSpiNewMsgFragSize( const UINT16 iReqMsgFragSize )
 {
    ABCC_ErrorCodeType eReturn = ABCC_EC_NO_ERROR;
-   if (iReqMsgFragSize < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN )
+   if( iReqMsgFragSize < ABCC_CFG_SPI_MIN_MSG_FRAG_LEN )
    {
       eReturn = ABCC_EC_PARAMETER_NOT_VALID;
    }
-   else if (iReqMsgFragSize > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN)
+   else if( iReqMsgFragSize > ABCC_CFG_SPI_MAX_MSG_FRAG_LEN )
    {
       eReturn = ABCC_EC_PARAMETER_NOT_VALID;
    }
-   else if (NUM_BYTES_2_WORDS(iReqMsgFragSize) == spi_drv_iPdOffset)
+   else if( NUM_BYTES_2_WORDS( iReqMsgFragSize ) == spi_drv_iPdOffset )
    {
-      //message fragment length did not change
-      eReturn = ABCC_EC_PARAMETER_NOT_VALID;
+      // requested message fragment length is OK, but did not change
+      // => no need to update fragmentation info or frame offsets
+      spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq = iReqMsgFragSize;
+      spi_drv_sSpiMsgFragSizeInfo.fUpdated = FALSE;
    }
+   else
    {
       spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq = iReqMsgFragSize;
       spi_drv_sSpiMsgFragSizeInfo.fUpdated = TRUE;
    }
-   return(eReturn);
+   return( eReturn );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -233,6 +233,7 @@ void ABCC_DrvSpiRunDriverTx( void )
 {
    #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
    INT16 i;
+   UINT16 iMsgFragSizeReqBuffer;
    #endif
    UINT32 lCrc;
    BOOL   fHandleWriteMsg = FALSE;
@@ -252,8 +253,11 @@ void ABCC_DrvSpiRunDriverTx( void )
          spi_drv_sMosiFrame.iSpiControl ^= iSpiCtrl_T;
 
          #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+         ABCC_PORT_EnterCritical();
          if( spi_drv_sSpiMsgFragSizeInfo.fUpdated )
          {
+            iMsgFragSizeReqBuffer = spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq;
+            ABCC_PORT_ExitCritical();
             /*
             ** The message fragment size has been updated since last 
             ** transmission, update the frame layout accordingly.
@@ -264,7 +268,7 @@ void ABCC_DrvSpiRunDriverTx( void )
                ** shift process data to new offset in frame according to new
                ** message fragment size
                */
-               if( spi_drv_iPdOffset < NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) )
+               if( spi_drv_iPdOffset < NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer ) )
                {
                   /*
                   ** move process data towards the end of the frame
@@ -275,7 +279,7 @@ void ABCC_DrvSpiRunDriverTx( void )
                   do
                   {
                      i--;
-                     spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
+                     spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer ) + i ] =
                         spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
                   }
                   while( i > 0 );
@@ -289,19 +293,33 @@ void ABCC_DrvSpiRunDriverTx( void )
                   */
                   for( i = 0; i < spi_drv_iPdSize; i++ )
                   {
-                     spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + i ] =
+                     spi_drv_sMosiFrame.iData[ NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer ) + i ] =
                         spi_drv_sMosiFrame.iData[ spi_drv_iPdOffset + i ];
                   }
                }
             }
-            spi_drv_iPdOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
-            spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq ) + spi_drv_iPdSize;
-            spi_drv_iMsgLen = NUM_BYTES_2_WORDS( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq );
+            spi_drv_iPdOffset = NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer );
+            spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer ) + spi_drv_iPdSize;
+            spi_drv_iMsgLen = NUM_BYTES_2_WORDS( iMsgFragSizeReqBuffer );
             spi_drv_sMosiFrame.iMsgLen = iTOiLe( spi_drv_iMsgLen );
             spi_drv_iSpiFrameSize = SPI_FRAME_SIZE_EXCLUDING_DATA + spi_drv_iCrcOffset;
 
-            spi_drv_sSpiMsgFragSizeInfo.fUpdated = FALSE;
+            ABCC_PORT_EnterCritical();
+            if( spi_drv_sSpiMsgFragSizeInfo.iMsgFragSizeReq == iMsgFragSizeReqBuffer )
+            {
+               spi_drv_sSpiMsgFragSizeInfo.fUpdated = FALSE;
+            }
+            else
+            {
+               /*
+               ** The message fragment size has been updated again since we
+               ** began to change it.
+               ** => repeat the update process on next driver call.
+               */
+               spi_drv_sSpiMsgFragSizeInfo.fUpdated = TRUE;
+            }
          }
+         ABCC_PORT_ExitCritical();
          #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
       }
 

--- a/src/spi/abcc_spi_driver.c
+++ b/src/spi/abcc_spi_driver.c
@@ -204,8 +204,8 @@ static UINT16                       spi_drv_iMsgLen;              /* Message len
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 static drv_SpiMsgFragSizeInfoType   spi_drv_sSpiMsgFragSizeInfo =
                                     {
-                                    FALSE,                     //BOOL     fUpdated;
-                                    ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE,// UINT16   iMsgFragSizeReq;
+                                    FALSE,                        /* BOOL fUpdated */
+                                    ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN, /* UINT16 iMsgFragSizeReq */
                                     };
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
@@ -663,8 +663,8 @@ void ABCC_DrvSpiInit( UINT8 bOpmode )
    spi_drv_iWritePdSize = SPI_DEFAULT_PD_LEN;
    spi_drv_iReadPdSize = SPI_DEFAULT_PD_LEN;
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-   spi_drv_iPdOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE );
-   spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE ) + SPI_DEFAULT_PD_LEN;
+   spi_drv_iPdOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN );
+   spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ) + SPI_DEFAULT_PD_LEN;
 #else
    spi_drv_iPdOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN );
    spi_drv_iCrcOffset = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN ) + SPI_DEFAULT_PD_LEN;
@@ -674,7 +674,7 @@ void ABCC_DrvSpiInit( UINT8 bOpmode )
    spi_drv_iMsgLen = 0;
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-   spi_drv_iMsgLen = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_SIZE );
+   spi_drv_iMsgLen = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN );
 #else
    spi_drv_iMsgLen = NUM_BYTES_2_WORDS( ABCC_CFG_SPI_MSG_FRAG_LEN );
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN


### PR DESCRIPTION
### Background
By increasing the message fragment size within the SPI frame, the data throughput can be increased for example for file transfers.
Most of the time the SPI frame does not transport message data. Therefore, a big message fragment size just increases transmission time and has a negative impact on possible reaction times for process data.
With the possibility to change the fragment size at runtime (supported by ABCC40), the application can use appropriate sizes for different use cases / operating modes.
### Usage
The functionality can be enabled by 
`#define ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN 1`
in abcc_driver_config.h.
Changing message fragment length at runtime can then be done by calling the function
`EXTFUNC ABCC_ErrorCodeType ABCC_NewMsgFragSize ( const UINT16 iReqMsgFragSize );`
By default,
`#define ABCC_CFG_SPI_MAX_MSG_FRAG_LEN ( ABCC_CFG_MAX_MSG_SIZE + 12) /* 12 bytes for the message header */`
`#define ABCC_CFG_SPI_MIN_MSG_FRAG_LEN 16`
are used as biggest and smallest allowed message fragment length, while 
`#define ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN ABCC_CFG_SPI_MSG_FRAG_LEN`
is used as default fragment length at system startup.
The defines can be changed within abcc_driver_config.h to specify own borders.
Defining minimum length below 8 or defining maximum length bigger than maximum supported message size will generate errors. 
