### PR TITLE
A7077E-68 Rename *_FLOG defines to *_FATAL_LOG

### DIFF
--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -748,6 +748,10 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 ** The main purpose of this is to make multiple occurrences of the same fault
 ** easier to distinguish from each other.
 **
+** Note:
+** ABCC_CFG_DEBUG_CLR_FATAL_LOG has no effect unless ABCC_CFG_DEBUG_GET_FATAL_LOG
+** is also enabled.
+**
 ** WARNING:
 ** ABCC_CFG_DEBUG_CLR_FATAL_LOG should *NOT* be enabled unless the printouts from
 ** the driver are being logged and saved!
@@ -758,6 +762,10 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 #endif
 #ifndef ABCC_CFG_DEBUG_CLR_FATAL_LOG
    #define ABCC_CFG_DEBUG_CLR_FATAL_LOG 0
+#endif
+
+#if ABCC_CFG_DEBUG_CLR_FATAL_LOG && !ABCC_CFG_DEBUG_GET_FATAL_LOG
+    #error "ABCC_CFG_DEBUG_CLR_FATAL_LOG requires ABCC_CFG_DEBUG_GET_FATAL_LOG to be enabled."
 #endif
 
 /*------------------------------------------------------------------------------

--- a/inc/abcc_config.h
+++ b/inc/abcc_config.h
@@ -736,28 +736,28 @@ ABCC_CFG_DRV_PARALLEL_ENABLED and ABCC_CFG_MEMORY_MAPPED_ACCESS_ENABLED are enab
 **
 ** Default values can be overridden in abcc_driver_config.h
 **
-** #define ABCC_CFG_DEBUG_GET_FLOG        1 - Enable / 0 - Disable
+** #define ABCC_CFG_DEBUG_GET_FATAL_LOG        1 - Enable / 0 - Disable
 **
 ** Enable/disable the inclusion of the extra GetAttribute command during the
 ** SETUP state, the data in the log is printed to the output terminal using
 ** the ABCC_PORT_printf() macro.
 **
-** #define ABCC_CFG_DEBUG_CLR_FLOG        1 - Enable / 0 - Disable
+** #define ABCC_CFG_DEBUG_CLR_FATAL_LOG        1 - Enable / 0 - Disable
 **
 ** Enable/disable automatic clearing of the Fatal log, if a log entry exists.
 ** The main purpose of this is to make multiple occurrences of the same fault
 ** easier to distinguish from each other.
 **
 ** WARNING:
-** ABCC_CFG_DEBUG_CLR_FLOG should *NOT* be enabled unless the printouts from
+** ABCC_CFG_DEBUG_CLR_FATAL_LOG should *NOT* be enabled unless the printouts from
 ** the driver are being logged and saved!
 **------------------------------------------------------------------------------
 */
-#ifndef ABCC_CFG_DEBUG_GET_FLOG
-   #define ABCC_CFG_DEBUG_GET_FLOG 0
+#ifndef ABCC_CFG_DEBUG_GET_FATAL_LOG
+   #define ABCC_CFG_DEBUG_GET_FATAL_LOG 0
 #endif
-#ifndef ABCC_CFG_DEBUG_CLR_FLOG
-   #define ABCC_CFG_DEBUG_CLR_FLOG 0
+#ifndef ABCC_CFG_DEBUG_CLR_FATAL_LOG
+   #define ABCC_CFG_DEBUG_CLR_FATAL_LOG 0
 #endif
 
 /*------------------------------------------------------------------------------

--- a/src/abcc_setup.c
+++ b/src/abcc_setup.c
@@ -35,10 +35,10 @@ CmdSetupStateType;
 #if !ABCC_CFG_DRV_CMD_SEQ_ENABLED
 static void SendSetupCommand( ABP_MsgType* psMsg );
 #endif
-#if ABCC_CFG_DEBUG_GET_FLOG
+#if ABCC_CFG_DEBUG_GET_FATAL_LOG
 static ABCC_CmdSeqCmdStatusType GetFatalLogCmd( ABP_MsgType* psMsg, void* pxUserData );
 static ABCC_CmdSeqRespStatusType GetFatalLogResp( ABP_MsgType* psMsg, void* pxUserData );
-#if ABCC_CFG_DEBUG_CLR_FLOG
+#if ABCC_CFG_DEBUG_CLR_FATAL_LOG
 static ABCC_CmdSeqCmdStatusType ClearFatalLogCmd( ABP_MsgType* psMsg, void* pxUserData );
 #endif
 #endif
@@ -80,9 +80,9 @@ static void SetupDone( const ABCC_CmdSeqResultType eSeqResult, void* pxUserData 
 */
 static const ABCC_CmdSeqType SetupSeqBeforeUserInit[] =
 {
-#if ABCC_CFG_DEBUG_GET_FLOG
+#if ABCC_CFG_DEBUG_GET_FATAL_LOG
    ABCC_CMD_SEQ( GetFatalLogCmd,     GetFatalLogResp ),
-#if ABCC_CFG_DEBUG_CLR_FLOG
+#if ABCC_CFG_DEBUG_CLR_FATAL_LOG
    ABCC_CMD_SEQ( ClearFatalLogCmd,   NULL ),
 #endif
 #endif
@@ -108,7 +108,7 @@ static const ABCC_CmdSeqType SetupSeqAfterUserInit[] =
 };
 
 
-#if ABCC_CFG_DEBUG_GET_FLOG && ABCC_CFG_DEBUG_CLR_FLOG
+#if ABCC_CFG_DEBUG_GET_FATAL_LOG && ABCC_CFG_DEBUG_CLR_FATAL_LOG
 static BOOL abcc_fClearFatalLog;
 #endif
 
@@ -304,7 +304,7 @@ void ABCC_SetupInit( void )
    abcc_iPdReadBitSize   = 0;
 }
 
-#if ABCC_CFG_DEBUG_GET_FLOG
+#if ABCC_CFG_DEBUG_GET_FATAL_LOG
 /*------------------------------------------------------------------------------
 ** Get fatal log command
 **
@@ -365,7 +365,7 @@ static ABCC_CmdSeqRespStatusType GetFatalLogResp( ABP_MsgType* psMsg, void* pxUs
       return( ABCC_CMDSEQ_RESP_ABORT );
    }
 
-#if ABCC_CFG_DEBUG_CLR_FLOG
+#if ABCC_CFG_DEBUG_CLR_FATAL_LOG
    /*
    ** Check the FW revision field to see if an event has been recorded, it
    ** should be non-zero then.
@@ -389,7 +389,7 @@ static ABCC_CmdSeqRespStatusType GetFatalLogResp( ABP_MsgType* psMsg, void* pxUs
    return( ABCC_CMDSEQ_RESP_EXEC_NEXT );
 }
 
-#if ABCC_CFG_DEBUG_CLR_FLOG
+#if ABCC_CFG_DEBUG_CLR_FATAL_LOG
 /*------------------------------------------------------------------------------
 ** Clear fatal log command
 **


### PR DESCRIPTION
Backward incompatible name changes of debug configuration macros used to fetch/clear the ABCC “Fatal log” from *_FLOG to *_FATAL_LOG.  Since this functionality was just recently added, the risk of breaking is rather low.

Changes:

- Renamed ABCC_CFG_DEBUG_GET_FLOG → ABCC_CFG_DEBUG_GET_FATAL_LOG
- Renamed ABCC_CFG_DEBUG_CLR_FLOG → ABCC_CFG_DEBUG_CLR_FATAL_LOG
- Added pre-processor dependency check since ABCC_CFG_DEBUG_CLR_FATAL_LOG is nested under the ABCC_CFG_DEBUG_GET_FATAL_LOG block
  